### PR TITLE
updated vagrant download link

### DIFF
--- a/manuscript/vagrant.md
+++ b/manuscript/vagrant.md
@@ -50,9 +50,7 @@ Installing vagrant is pretty easy. Just grab the downloader for your operating s
 
 **download vagrant:**
 
-[http://downloads.vagrantup.com](http://downloads.vagrantup.com)
-
-You'll see a list of version numbers on that first page – just click the very top one to get the latest release of vagrant.
+[http://www.vagrantup.com/downloads.html](http://www.vagrantup.com/downloads.html)
 
 **installation instructions:**
 


### PR DESCRIPTION
hey seth :) hope you don't mind me playing around here. like I said, I'm pretty thorough ;)

this page: http://downloads.vagrantup.com/ says that it's actually an archive of old vagrant versions, so I updated the download link to the new one: http://www.vagrantup.com/downloads.html

and also deleted the line "You’ll see a list of version numbers on that first page – just click the very top one to get the latest release of vagrant." since it's no longer relevant :)
