### PR TITLE
Update 10-javascript.md

### DIFF
--- a/chapters/10-javascript.md
+++ b/chapters/10-javascript.md
@@ -122,7 +122,7 @@ We have git installed, so we can clone nvm to our home folder:
 git clone https://github.com/creationix/nvm.git ~/.nvm
 ~~~~~~~~
 
-Source nvm to make it the `nvm` command available in the terminal:
+Source nvm to make the `nvm` command available in the terminal by typing into your terminal:
 
 ~~~~~~~~
 source ~/.nvm/nvm.sh


### PR DESCRIPTION
11: before talking about node explain further what exactly it is
"Language website" is also a pretty awkward-sounding header.
never mind, you used it for the "Ruby" chapter, too.
but it made more sense then cos it was just a link.
here it's just confusing because you talk about nodejs.
idk.
"Website for the language" might be too long but for the point of clarity/parallelism you may consider changing all the "Language website" headers to that.
